### PR TITLE
Fix case insensitive comparisons for moderator username and others

### DIFF
--- a/backend/src/__tests__/submission.service.test.ts
+++ b/backend/src/__tests__/submission.service.test.ts
@@ -752,7 +752,7 @@ describe("SubmissionService", () => {
       });
     });
 
-    it("should handle hashtags case-insensitively", async () => {
+    it("should handle hashtags and moderator names case-insensitively", async () => {
       // Original tweet being submitted
       const originalTweet: Tweet = {
         id: TWEET_IDS.original1_tweet,
@@ -772,7 +772,7 @@ describe("SubmissionService", () => {
       const curatorTweet: Tweet = {
         id: TWEET_IDS.curator1_reply,
         text: "@test_bot !submit #DeSci #DAO",
-        username: curator1.username,
+        username: "CURATOR1", // Different case than config which has "curator1"
         userId: curator1.id,
         inReplyToStatusId: TWEET_IDS.original1_tweet,
         timeParsed: new Date(),
@@ -799,7 +799,7 @@ describe("SubmissionService", () => {
         userId: user1.id,
         username: user1.username,
         curatorId: curator1.id,
-        curatorUsername: curator1.username,
+        curatorUsername: "CURATOR1",
         content: "Original content",
         createdAt: expect.any(String),
         submittedAt: expect.any(String),
@@ -809,7 +809,7 @@ describe("SubmissionService", () => {
       // Verify feed submissions were saved with case-insensitive matching
       expect(drizzleMock.saveSubmissionToFeed).toHaveBeenCalledTimes(2);
 
-      // Both feeds should be saved as pending initially
+      // Both feeds should be saved and auto-approved since curator1 is a moderator
       expect(drizzleMock.saveSubmissionToFeed.mock.calls[0]).toEqual([
         TWEET_IDS.original1_tweet,
         "DeSci", // Should match feed ID
@@ -820,6 +820,44 @@ describe("SubmissionService", () => {
         "DAO", // Should match feed ID
         SubmissionStatus.PENDING,
       ]);
+
+      // Verify both feeds were auto-approved despite case difference in moderator name
+      expect(drizzleMock.updateSubmissionFeedStatus).toHaveBeenCalledTimes(2);
+      expect(drizzleMock.updateSubmissionFeedStatus).toHaveBeenCalledWith(
+        TWEET_IDS.original1_tweet,
+        "DeSci",
+        SubmissionStatus.APPROVED,
+        TWEET_IDS.curator1_reply,
+      );
+      expect(drizzleMock.updateSubmissionFeedStatus).toHaveBeenCalledWith(
+        TWEET_IDS.original1_tweet,
+        "DAO",
+        SubmissionStatus.APPROVED,
+        TWEET_IDS.curator1_reply,
+      );
+
+      // Verify moderation history was saved for both auto-approvals
+      expect(drizzleMock.saveModerationAction).toHaveBeenCalledTimes(2);
+      expect(drizzleMock.saveModerationAction).toHaveBeenCalledWith(
+        expect.objectContaining({
+          tweetId: TWEET_IDS.original1_tweet,
+          feedId: "DeSci",
+          adminId: "CURATOR1",
+          action: "approve",
+          note: expect.any(String),
+          timestamp: expect.any(Date),
+        }),
+      );
+      expect(drizzleMock.saveModerationAction).toHaveBeenCalledWith(
+        expect.objectContaining({
+          tweetId: TWEET_IDS.original1_tweet,
+          feedId: "DAO",
+          adminId: "CURATOR1",
+          action: "approve",
+          note: expect.any(String),
+          timestamp: expect.any(Date),
+        }),
+      );
     });
 
     it("should ignore submissions from blacklisted users", async () => {

--- a/backend/src/__tests__/submission.service.test.ts
+++ b/backend/src/__tests__/submission.service.test.ts
@@ -768,10 +768,10 @@ describe("SubmissionService", () => {
         thread: [],
       };
 
-      // Curator submitting with differently cased hashtags
+      // Curator submitting with different casing
       const curatorTweet: Tweet = {
         id: TWEET_IDS.curator1_reply,
-        text: "@test_bot !submit #DeSci #DAO",
+        text: "@TEST_BOT !SUBMIT #DeSci #DAO", // Different case for bot name and command
         username: "CURATOR1", // Different case than config which has "curator1"
         userId: curator1.id,
         inReplyToStatusId: TWEET_IDS.original1_tweet,

--- a/backend/src/services/submissions/submission.service.ts
+++ b/backend/src/services/submissions/submission.service.ts
@@ -260,8 +260,8 @@ export class SubmissionService {
           continue;
         }
 
-        const isModerator = feed.moderation.approvers.twitter.includes(
-          curatorTweet.username!,
+        const isModerator = feed.moderation.approvers.twitter.some(
+          (approver) => approver.toLowerCase() === curatorTweet.username!.toLowerCase()
         );
         const existingFeed = existingFeeds.find(
           (f) => f.feedId.toLowerCase() === lowercaseFeedId,
@@ -403,7 +403,9 @@ export class SubmissionService {
       .filter((feed) => feed.status === SubmissionStatus.PENDING)
       .filter((feed) => {
         const feedConfig = this.config.feeds.find((f) => f.id === feed.feedId);
-        return feedConfig?.moderation.approvers.twitter.includes(adminUsername);
+        return feedConfig?.moderation.approvers.twitter.some(
+          (approver) => approver.toLowerCase() === adminUsername.toLowerCase()
+        );
       });
 
     if (pendingFeeds.length === 0) {

--- a/backend/src/services/submissions/submission.service.ts
+++ b/backend/src/services/submissions/submission.service.ts
@@ -160,8 +160,12 @@ export class SubmissionService {
       }
 
       if (
-        curatorTweet.username === this.config.global.botId || // if self
-        this.config.global.blacklist["twitter"].includes(curatorTweet.username)
+        curatorTweet.username.toLowerCase() ===
+          this.config.global.botId.toLowerCase() || // if self
+        this.config.global.blacklist["twitter"].some(
+          (blacklisted) =>
+            blacklisted.toLowerCase() === curatorTweet.username?.toLowerCase(),
+        )
       ) {
         logger.error(`${tweet.id}: Submitted by bot or blacklisted user`);
         // or blacklisted
@@ -261,7 +265,8 @@ export class SubmissionService {
         }
 
         const isModerator = feed.moderation.approvers.twitter.some(
-          (approver) => approver.toLowerCase() === curatorTweet.username!.toLowerCase()
+          (approver) =>
+            approver.toLowerCase() === curatorTweet.username!.toLowerCase(),
         );
         const existingFeed = existingFeeds.find(
           (f) => f.feedId.toLowerCase() === lowercaseFeedId,
@@ -404,7 +409,7 @@ export class SubmissionService {
       .filter((feed) => {
         const feedConfig = this.config.feeds.find((f) => f.id === feed.feedId);
         return feedConfig?.moderation.approvers.twitter.some(
-          (approver) => approver.toLowerCase() === adminUsername.toLowerCase()
+          (approver) => approver.toLowerCase() === adminUsername.toLowerCase(),
         );
       });
 
@@ -508,10 +513,9 @@ export class SubmissionService {
 
   private getModerationAction(tweet: Tweet): "approve" | "reject" | null {
     const hashtags = tweet.hashtags?.map((tag) => tag.toLowerCase()) || [];
-    if (tweet.text?.includes("!approve") || hashtags.includes("approve"))
-      return "approve";
-    if (tweet.text?.includes("!reject") || hashtags.includes("reject"))
-      return "reject";
+    const text = tweet.text?.toLowerCase() || "";
+    if (text.includes("!approve")) return "approve";
+    if (text.includes("!reject")) return "reject";
     return null;
   }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved text handling so that hashtags and moderator commands are processed case-insensitively. This update ensures that submissions and auto-approvals work reliably regardless of text casing, providing a more consistent moderation experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->