### PR TITLE
fix: transparent toasts

### DIFF
--- a/apps/app/src/components/ui/toast.tsx
+++ b/apps/app/src/components/ui/toast.tsx
@@ -29,7 +29,7 @@ const toastVariants = cva(
       variant: {
         default: "bg-white text-foreground", // Assuming 'foreground' is defined in Tailwind config
         destructive:
-          "destructive group border-destructive bg-destructive text-destructive-foreground bg-red-100",
+          "destructive group border-destructive bg-destructive text-destructive-foreground",
         success: "success group border-green-600 bg-green-100 text-green-800",
       },
     },

--- a/apps/app/src/components/ui/toast.tsx
+++ b/apps/app/src/components/ui/toast.tsx
@@ -29,7 +29,7 @@ const toastVariants = cva(
       variant: {
         default: "bg-white text-foreground", // Assuming 'foreground' is defined in Tailwind config
         destructive:
-          "destructive group border-destructive bg-destructive text-destructive-foreground",
+          "destructive group border-destructive bg-destructive text-destructive-foreground bg-red-100",
         success: "success group border-green-600 bg-green-100 text-green-800",
       },
     },

--- a/apps/app/tailwind.config.js
+++ b/apps/app/tailwind.config.js
@@ -14,6 +14,12 @@ export default {
         sharp: "4px 4px 0 rgba(0, 0, 0, 1)",
         "sharp-hover": "6px 6px 0 rgba(0, 0, 0, 1)",
       },
+      colors: {
+        destructive: {
+          DEFAULT: 'oklch(var(--destructive))',
+          foreground: 'oklch(var(--destructive-foreground))',
+        },
+      },
     },
   },
   plugins: [typography],

--- a/apps/app/tailwind.config.js
+++ b/apps/app/tailwind.config.js
@@ -16,8 +16,8 @@ export default {
       },
       colors: {
         destructive: {
-          DEFAULT: 'oklch(var(--destructive))',
-          foreground: 'oklch(var(--destructive-foreground))',
+          DEFAULT: "oklch(var(--destructive))",
+          foreground: "oklch(var(--destructive-foreground))",
         },
       },
     },


### PR DESCRIPTION
Preview of all variants of toasts

![image](https://github.com/user-attachments/assets/e8c95edf-ecd2-4ff7-9f16-56728d2479e6)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Style**
  - Added a new "destructive" color palette to the app's theme, enhancing visual consistency for destructive actions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->