### PR TITLE
fix: "posting to" showing when there are no feed distributors

### DIFF
--- a/apps/app/src/components/DistributorBadges.tsx
+++ b/apps/app/src/components/DistributorBadges.tsx
@@ -1,0 +1,24 @@
+import { Badge } from "./ui/badge";
+
+export function DistributorBadges({
+  distribute,
+}: {
+  distribute: { plugin: string }[];
+}) {
+  return (
+    <>
+      <p className="flex">Posting to:</p>
+      {distribute.map((distributor) => {
+        const pluginName = distributor.plugin.replace("@curatedotfun/", "");
+        return (
+          <Badge
+            key={distributor.plugin}
+            className="text-black border border-stone-500 rounded-md bg-stone-50 shadow-none capitalize px-2 py-0.5"
+          >
+            {pluginName}
+          </Badge>
+        );
+      })}
+    </>
+  );
+}

--- a/apps/app/src/routes/_layout/feed/$feedId.tsx
+++ b/apps/app/src/routes/_layout/feed/$feedId.tsx
@@ -3,6 +3,7 @@ import { ListFilter } from "lucide-react";
 import FeedLayout from "../../../components/FeedLayout";
 import { Badge } from "../../../components/ui/badge";
 import { useFeed } from "../../../lib/api";
+import { DistributorBadges } from "../../../components/DistributorBadges";
 
 const TABS = [
   // {
@@ -94,23 +95,13 @@ function FeedPageLayout() {
                 Twitter
               </Badge>
             </div>
-            <div className="flex  sm:flex-row items-center gap-2 justify-end sm:gap-3 w-full sm:w-full">
-              <p className="flex">Posting to:</p>
-              {feed?.config?.outputs?.stream?.distribute?.map((distributor) => {
-                const pluginName = distributor.plugin.replace(
-                  "@curatedotfun/",
-                  "",
-                );
-                return (
-                  <Badge
-                    key={distributor.plugin}
-                    className="text-black border border-stone-500 rounded-md bg-stone-50 shadow-none capitalize px-2 py-0.5"
-                  >
-                    {pluginName}
-                  </Badge>
-                );
-              })}
-            </div>
+            {(feed?.config?.outputs?.stream?.distribute?.length ?? 0) > 0 && (
+              <div className="flex sm:flex-row items-center gap-2 justify-end sm:gap-3 w-full sm:w-full">
+                <DistributorBadges
+                  distribute={feed?.config?.outputs?.stream?.distribute ?? []}
+                />
+              </div>
+            )}
           </div>
         </div>
 


### PR DESCRIPTION
Showing for feeds with posting to distributors
![image](https://github.com/user-attachments/assets/fcd1be8d-2096-4697-9460-4260560f2c78)

Not showing for feeds with no distributors
![image](https://github.com/user-attachments/assets/38294039-d440-4ebe-b9e8-fedf3fc656f7)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new component for displaying distributor badges in the feed layout.

- **Refactor**
  - Improved the feed layout by encapsulating badge rendering into a reusable component for better maintainability and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->