### PR TITLE
feat: welcome route for new feed

### DIFF
--- a/apps/app/src/components/leaderboard/LeaderboardColumns.tsx
+++ b/apps/app/src/components/leaderboard/LeaderboardColumns.tsx
@@ -88,9 +88,11 @@ export function createLeaderboardColumns(
           <div className="flex flex-col min-h-[32px] justify-center">
             <div className="flex items-center gap-2">
               {feedSubmissions && feedSubmissions.length > 0 && (
-                <div className="flex items-center justify-between gap-1 border border-neutral-400 px-2 py-1 rounded-md w-[150px]">
-                  <span className="text-sm">#{feedSubmissions[0].feedId}</span>
-                  <span className="text-sm">
+                <div className="flex items-center justify-between gap-1 border border-neutral-400 px-2 py-1 rounded-md w-[150px] min-w-0">
+                  <span className="text-sm truncate flex-shrink">
+                    #{feedSubmissions[0].feedId}
+                  </span>
+                  <span className="text-sm whitespace-nowrap flex-shrink-0">
                     {feedSubmissions[0].count}/{feedSubmissions[0].totalInFeed}
                   </span>
                 </div>
@@ -116,9 +118,11 @@ export function createLeaderboardColumns(
               <div className="flex flex-col gap-2 mt-2 pl-0">
                 {feedSubmissions.slice(1).map((feed, feedIndex) => (
                   <div key={feedIndex} className="flex items-center">
-                    <div className="flex items-center gap-1 border border-neutral-400 px-2 py-1 rounded-md justify-between w-[150px]">
-                      <span className="text-sm">#{feed.feedId}</span>
-                      <span className="text-sm">
+                    <div className="flex items-center gap-1 border border-neutral-400 px-2 py-1 rounded-md justify-between w-[150px] min-w-0">
+                      <span className="text-sm truncate flex-shrink">
+                        #{feed.feedId}
+                      </span>
+                      <span className="text-sm whitespace-nowrap flex-shrink-0">
                         {feed.count}/{feed.totalInFeed}
                       </span>
                     </div>

--- a/apps/app/src/routeTree.gen.ts
+++ b/apps/app/src/routeTree.gen.ts
@@ -25,6 +25,7 @@ import { Route as LayoutCreateFeedIndexRouteImport } from "./routes/_layout/crea
 import { Route as LayoutProfileSettingsPreferencesRouteImport } from "./routes/_layout/profile/settings/preferences";
 import { Route as LayoutProfileSettingsNotificationsRouteImport } from "./routes/_layout/profile/settings/notifications";
 import { Route as LayoutProfileSettingsConnectionsRouteImport } from "./routes/_layout/profile/settings/connections";
+import { Route as LayoutFeedWelcomeFeedIdRouteImport } from "./routes/_layout/feed/welcome/$feedId";
 import { Route as LayoutFeedFeedIdTokenRouteImport } from "./routes/_layout/feed/$feedId/token";
 import { Route as LayoutFeedFeedIdProposalsRouteImport } from "./routes/_layout/feed/$feedId/proposals";
 import { Route as LayoutFeedFeedIdPointsRouteImport } from "./routes/_layout/feed/$feedId/points";
@@ -120,6 +121,11 @@ const LayoutProfileSettingsConnectionsRoute =
     path: "/connections",
     getParentRoute: () => LayoutProfileSettingsRouteRoute,
   } as any);
+const LayoutFeedWelcomeFeedIdRoute = LayoutFeedWelcomeFeedIdRouteImport.update({
+  id: "/feed/welcome/$feedId",
+  path: "/feed/welcome/$feedId",
+  getParentRoute: () => LayoutRoute,
+} as any);
 const LayoutFeedFeedIdTokenRoute = LayoutFeedFeedIdTokenRouteImport.update({
   id: "/token",
   path: "/token",
@@ -194,6 +200,7 @@ export interface FileRoutesByFullPath {
   "/feed/$feedId/points": typeof LayoutFeedFeedIdPointsRoute;
   "/feed/$feedId/proposals": typeof LayoutFeedFeedIdProposalsRoute;
   "/feed/$feedId/token": typeof LayoutFeedFeedIdTokenRoute;
+  "/feed/welcome/$feedId": typeof LayoutFeedWelcomeFeedIdRoute;
   "/profile/settings/connections": typeof LayoutProfileSettingsConnectionsRoute;
   "/profile/settings/notifications": typeof LayoutProfileSettingsNotificationsRoute;
   "/profile/settings/preferences": typeof LayoutProfileSettingsPreferencesRoute;
@@ -218,6 +225,7 @@ export interface FileRoutesByTo {
   "/feed/$feedId/points": typeof LayoutFeedFeedIdPointsRoute;
   "/feed/$feedId/proposals": typeof LayoutFeedFeedIdProposalsRoute;
   "/feed/$feedId/token": typeof LayoutFeedFeedIdTokenRoute;
+  "/feed/welcome/$feedId": typeof LayoutFeedWelcomeFeedIdRoute;
   "/profile/settings/connections": typeof LayoutProfileSettingsConnectionsRoute;
   "/profile/settings/notifications": typeof LayoutProfileSettingsNotificationsRoute;
   "/profile/settings/preferences": typeof LayoutProfileSettingsPreferencesRoute;
@@ -247,6 +255,7 @@ export interface FileRoutesById {
   "/_layout/feed/$feedId/points": typeof LayoutFeedFeedIdPointsRoute;
   "/_layout/feed/$feedId/proposals": typeof LayoutFeedFeedIdProposalsRoute;
   "/_layout/feed/$feedId/token": typeof LayoutFeedFeedIdTokenRoute;
+  "/_layout/feed/welcome/$feedId": typeof LayoutFeedWelcomeFeedIdRoute;
   "/_layout/profile/settings/connections": typeof LayoutProfileSettingsConnectionsRoute;
   "/_layout/profile/settings/notifications": typeof LayoutProfileSettingsNotificationsRoute;
   "/_layout/profile/settings/preferences": typeof LayoutProfileSettingsPreferencesRoute;
@@ -276,6 +285,7 @@ export interface FileRouteTypes {
     | "/feed/$feedId/points"
     | "/feed/$feedId/proposals"
     | "/feed/$feedId/token"
+    | "/feed/welcome/$feedId"
     | "/profile/settings/connections"
     | "/profile/settings/notifications"
     | "/profile/settings/preferences"
@@ -300,6 +310,7 @@ export interface FileRouteTypes {
     | "/feed/$feedId/points"
     | "/feed/$feedId/proposals"
     | "/feed/$feedId/token"
+    | "/feed/welcome/$feedId"
     | "/profile/settings/connections"
     | "/profile/settings/notifications"
     | "/profile/settings/preferences"
@@ -328,6 +339,7 @@ export interface FileRouteTypes {
     | "/_layout/feed/$feedId/points"
     | "/_layout/feed/$feedId/proposals"
     | "/_layout/feed/$feedId/token"
+    | "/_layout/feed/welcome/$feedId"
     | "/_layout/profile/settings/connections"
     | "/_layout/profile/settings/notifications"
     | "/_layout/profile/settings/preferences"
@@ -455,6 +467,13 @@ declare module "@tanstack/react-router" {
       fullPath: "/profile/settings/connections";
       preLoaderRoute: typeof LayoutProfileSettingsConnectionsRouteImport;
       parentRoute: typeof LayoutProfileSettingsRouteRoute;
+    };
+    "/_layout/feed/welcome/$feedId": {
+      id: "/_layout/feed/welcome/$feedId";
+      path: "/feed/welcome/$feedId";
+      fullPath: "/feed/welcome/$feedId";
+      preLoaderRoute: typeof LayoutFeedWelcomeFeedIdRouteImport;
+      parentRoute: typeof LayoutRoute;
     };
     "/_layout/feed/$feedId/token": {
       id: "/_layout/feed/$feedId/token";
@@ -604,6 +623,7 @@ interface LayoutRouteChildren {
   LayoutPluginIndexRoute: typeof LayoutPluginIndexRoute;
   LayoutProfileIndexRoute: typeof LayoutProfileIndexRoute;
   LayoutEditFeedFeedIdRoute: typeof LayoutEditFeedFeedIdRoute;
+  LayoutFeedWelcomeFeedIdRoute: typeof LayoutFeedWelcomeFeedIdRoute;
 }
 
 const LayoutRouteChildren: LayoutRouteChildren = {
@@ -617,6 +637,7 @@ const LayoutRouteChildren: LayoutRouteChildren = {
   LayoutPluginIndexRoute: LayoutPluginIndexRoute,
   LayoutProfileIndexRoute: LayoutProfileIndexRoute,
   LayoutEditFeedFeedIdRoute: LayoutEditFeedFeedIdRoute,
+  LayoutFeedWelcomeFeedIdRoute: LayoutFeedWelcomeFeedIdRoute,
 };
 
 const LayoutRouteWithChildren =

--- a/apps/app/src/routes/_layout/create/feed/review.tsx
+++ b/apps/app/src/routes/_layout/create/feed/review.tsx
@@ -26,7 +26,10 @@ function FeedReviewComponent() {
         description: `Your feed "${feedConfig.name}" has been created.`,
         variant: "default",
       });
-      navigate({ to: "/" });
+      navigate({
+        to: "/feed/welcome/$feedId",
+        params: { feedId: feedConfig.id! },
+      });
     } catch (error) {
       console.error("Error creating feed:", error);
       toast({

--- a/apps/app/src/routes/_layout/feed/$feedId.tsx
+++ b/apps/app/src/routes/_layout/feed/$feedId.tsx
@@ -58,9 +58,12 @@ function FeedPageLayout() {
         <div className="flex flex-col gap-4 sm:gap-6 p-4 sm:p-6 rounded-md border border-neutral-400 bg-white">
           <div className="flex flex-col sm:flex-row sm:gap-[40px] gap-4 items-center sm:items-start w-full border-b border-1 border-dashed border-black pb-4">
             <img
-              src={feed?.config.image}
-              alt={feed?.config.name}
-              className="h-[80px] w-[80px] sm:h-[108px] sm:w-[108px]"
+              src={feed?.config.image || "/images/feed-image.png"}
+              alt={feed?.config.name || "Feed image"}
+              className="h-[80px] w-[80px] sm:h-[108px] sm:w-[108px] rounded-full object-cover"
+              onError={(e) => {
+                e.currentTarget.src = "/images/feed-image.png";
+              }}
             />
             <div className="flex flex-col gap-2 sm:gap-3 text-center sm:text-left">
               <div className="flex flex-col sm:flex-row sm:gap-[10px] gap-2 items-center">

--- a/apps/app/src/routes/_layout/feed/welcome/$feedId.tsx
+++ b/apps/app/src/routes/_layout/feed/welcome/$feedId.tsx
@@ -1,0 +1,121 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { useFeed } from "../../../../lib/api";
+import { Badge } from "@/components/ui/badge";
+import { formatDate } from "../../../../utils/datetime";
+import { ScrollText, Sparkles } from "lucide-react";
+import { Card } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+
+export const Route = createFileRoute("/_layout/feed/welcome/$feedId")({
+  component: FeedWelcomePage,
+});
+
+function FeedWelcomePage() {
+  const { feedId } = Route.useParams();
+  const { data: feed } = useFeed(feedId);
+
+  const steps = [
+    {
+      icon: (
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          x="0px"
+          y="0px"
+          width="24"
+          height="24"
+          viewBox="0 0 30 30"
+        >
+          <path d="M26.37,26l-8.795-12.822l0.015,0.012L25.52,4h-2.65l-6.46,7.48L11.28,4H4.33l8.211,11.971L12.54,15.97L3.88,26h2.65 l7.182-8.322L19.42,26H26.37z M10.23,6l12.34,18h-2.1L8.12,6H10.23z"></path>
+        </svg>
+      ),
+      title: "Add Content Sources",
+      description:
+        "Connect Twitter, RSS feeds, or other sources to curate content from",
+    },
+    {
+      icon: <Sparkles size={24} />,
+      title: "Set Up Content Generation",
+      description:
+        "Configure AI to automatically generate content from your sources.",
+    },
+    {
+      icon: <ScrollText size={24} />,
+      title: "Set Up Content Publishing",
+      description: "Set Up Content Publishing.",
+    },
+  ];
+
+  return (
+    <div className="max-w-[1440px] mx-auto w-full">
+      {/* Header with back button and feed title */}
+      <div className="flex flex-col px-4 sm:px-6 md:px-[70px] py-4 sm:py-[30px] gap-4 sm:gap-[30px]">
+        <div className="flex flex-col gap-4 sm:gap-6 p-4 sm:p-6 rounded-md border border-neutral-400 bg-white">
+          <div className="flex flex-col sm:flex-row sm:gap-[40px] gap-4 items-center sm:items-start w-full border-b border-1 border-dashed border-black pb-4">
+            <img
+              src={feed?.config.image}
+              alt={feed?.config.name}
+              className="h-[80px] w-[80px] sm:h-[108px] sm:w-[108px]"
+            />
+            <div className="flex flex-col gap-2 sm:gap-3 text-center sm:text-left">
+              <div className="flex flex-col sm:flex-row sm:gap-[10px] gap-2 items-center">
+                <h3 className="leading-8 sm:leading-10 text-xl sm:text-2xl font-[900]">
+                  {feed?.name || `Feed: ${feedId}`}
+                </h3>
+                <Badge>#{feed?.id}</Badge>
+              </div>
+              <p className="text-sm sm:text-base leading-[20px] sm:leading-[22px] text-neutral-800">
+                {feed?.description ||
+                  "View and manage all content for this feed"}
+              </p>
+              <p className="font-thin text-[15px] text-[#64748B]">
+                Created{" "}
+                {feed?.createdAt ? formatDate(feed.createdAt) : "Unknown"}
+              </p>
+            </div>
+          </div>
+          <div className="flex p-[35px] flex-col items-center justify-center gap-3.5 rounded border border-dashed border-neutral-500 bg-neutral-50">
+            <div className="flex flex-col gap-3.5 items-center justify-center max-w-[445px] w-full text-center">
+              <Sparkles size={32} />
+              <p className="font-[Roboto] text-base font-medium">
+                This Feed isn&apos;t set up yet
+              </p>
+              <p className="font-[Geist] text-sm font-medium">
+                Your feed needs content generation to be configured before it
+                can display content. Set up AI-powered content generation to
+                automatically create and publish content.
+              </p>
+            </div>
+          </div>
+        </div>
+        <div className="flex flex-col gap-6 items-center justify-center">
+          <div className="flex items-center gap-2 w-full max-w-md">
+            <div className="flex-1 h-[1px] bg-[#D9D9D9] min-w-[20px]" />
+            <p className="text-sm font-[Roboto] font-medium whitespace-nowrap px-2">
+              WHAT&apos;S NEXT ?
+            </p>
+            <div className="flex-1 h-[1px] bg-[#D9D9D9] min-w-[20px]" />
+          </div>
+          <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
+            {steps.map((step, index) => (
+              <Card
+                key={index}
+                className="px-[15px] py-[21px] flex flex-col gap-0 rounded border-neutral-200 w-full md:max-w-[245px]"
+              >
+                {step.icon}
+                <h4 className="mt-6 mb-4 font-[Roboto] text-base font-bold">
+                  {step.title}
+                </h4>
+                <p className="font-[Geist] text-sm font-medium">
+                  {step.description}
+                </p>
+              </Card>
+            ))}
+          </div>
+          <Button>Continue Feed Setup</Button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default FeedWelcomePage;

--- a/apps/app/src/routes/_layout/feed/welcome/$feedId.tsx
+++ b/apps/app/src/routes/_layout/feed/welcome/$feedId.tsx
@@ -1,4 +1,4 @@
-import { createFileRoute } from "@tanstack/react-router";
+import { createFileRoute, useNavigate } from "@tanstack/react-router";
 import { useFeed } from "../../../../lib/api";
 import { Badge } from "@/components/ui/badge";
 import { formatDate } from "../../../../utils/datetime";
@@ -12,7 +12,8 @@ export const Route = createFileRoute("/_layout/feed/welcome/$feedId")({
 
 function FeedWelcomePage() {
   const { feedId } = Route.useParams();
-  const { data: feed } = useFeed(feedId);
+  const navigate = useNavigate();
+  const { data: feed, isLoading, isError } = useFeed(feedId);
 
   const steps = [
     {
@@ -41,9 +42,32 @@ function FeedWelcomePage() {
     {
       icon: <ScrollText size={24} />,
       title: "Set Up Content Publishing",
-      description: "Set Up Content Publishing.",
+      description:
+        "Configure AI to automatically generate content from your sources.",
     },
   ];
+
+  if (isLoading) {
+    return (
+      <div className="flex items-center justify-center min-h-[400px]">
+        <div className="text-center">
+          <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-gray-900 mx-auto mb-4"></div>
+          <p>Loading feed...</p>
+        </div>
+      </div>
+    );
+  }
+
+  if (isError) {
+    return (
+      <div className="flex items-center justify-center min-h-[400px]">
+        <div className="text-center">
+          <p className="text-red-600 mb-4">Failed to load feed</p>
+          <Button onClick={() => window.location.reload()}>Retry</Button>
+        </div>
+      </div>
+    );
+  }
 
   return (
     <div className="max-w-[1440px] mx-auto w-full">
@@ -52,9 +76,12 @@ function FeedWelcomePage() {
         <div className="flex flex-col gap-4 sm:gap-6 p-4 sm:p-6 rounded-md border border-neutral-400 bg-white">
           <div className="flex flex-col sm:flex-row sm:gap-[40px] gap-4 items-center sm:items-start w-full border-b border-1 border-dashed border-black pb-4">
             <img
-              src={feed?.config.image}
-              alt={feed?.config.name}
-              className="h-[80px] w-[80px] sm:h-[108px] sm:w-[108px]"
+              src={feed?.config.image || "/images/feed-image.png"}
+              alt={feed?.config.name || "Feed image"}
+              className="h-[80px] w-[80px] sm:h-[108px] sm:w-[108px] rounded-full object-cover"
+              onError={(e) => {
+                e.currentTarget.src = "/images/feed-image.png";
+              }}
             />
             <div className="flex flex-col gap-2 sm:gap-3 text-center sm:text-left">
               <div className="flex flex-col sm:flex-row sm:gap-[10px] gap-2 items-center">
@@ -111,7 +138,13 @@ function FeedWelcomePage() {
               </Card>
             ))}
           </div>
-          <Button>Continue Feed Setup</Button>
+          <Button
+            onClick={() =>
+              navigate({ to: "/feed/$feedId/settings", params: { feedId } })
+            }
+          >
+            Continue Feed Setup
+          </Button>
         </div>
       </div>
     </div>


### PR DESCRIPTION
Preview:

![localhost_5173_feed_welcome_cat](https://github.com/user-attachments/assets/da63772b-32c5-4fab-897f-c1125d97566b)

Redirection after creating new feed is working. Created a new route at /feed/welcome/$feedId 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a dedicated welcome page for newly created feeds, displaying feed details and setup steps.
	- After creating a feed, users are now redirected to the feed-specific welcome page instead of the homepage.

- **Enhancements**
	- The welcome page guides users through next steps for setting up their feed, including adding content sources, configuring content generation, and publishing.

- **Navigation**
	- Improved post-creation navigation flow to streamline onboarding for new feeds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->